### PR TITLE
Update `jsonschema` dependency to `jsonschema-with-format`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=3.6
   run:
     - jsonref
-    - jsonschema >=2.5.1
+    - jsonschema-with-format >=2.5.1
     - msgpack-python >=0.5.2
     - requests
     - python >=3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0da9c6f3814734622a55db3f62d08db6e188b25f3ebd087de370c91afb66a7f4
 
 build:
-  number: 0
+  number: 1
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv '
   noarch: python
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #20 

<!--
Please add any other relevant info below:
-->
To be honest I cannot build a conda recipe yet. This is my best guess about fixing the issue. Considering that the `jsonschema` word occurs in one place only in the whole repository, I think it is a good guess. One problem might be that the oldest `jsonschema` version is **2.5.1** while the oldest version of the proposed `jsonschema-with-format` is **4.2.1** so it might raise compatibility issues. I am sorry if the proposed solution is not the correct one. Please reject my PR in that case.